### PR TITLE
Adjust backup schedule query

### DIFF
--- a/router-download.php
+++ b/router-download.php
@@ -50,7 +50,7 @@ $t = $stime = time();
 $devices = db_fetch_assoc("SELECT * 
 	FROM plugin_routerconfigs_devices 
 	WHERE enabled = 'on' 
-	AND ($t - (schedule * 86400)) - 3600 > lastbackup");
+        AND ((($t - lastbackup) - (schedule * 86400)) > -3600)");
 
 $failed = array();
 if (sizeof($devices)) {


### PR DESCRIPTION
Backups set for schedule of 1 (1 day = 86400 seconds) was not completing daily, and would only backup every other day.