### PR TITLE
Fix issue with automated backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: Correct most config comparision code
 * issue: Added in missing Horde library functions and created common include file 
 * issue: Fixed the poller spawn issue that was preventing automatic backups
+* issue: Fixed comparison device/file selection code
 * feature: Backups - Now all use same code
 * feature: Backups - Manual now work the same way as automatic ones
 * feature: Backups - Manual can be done regardless of last attempt state

--- a/functions.php
+++ b/functions.php
@@ -126,11 +126,13 @@ function plugin_routerconfigs_download($retry = false, $force = false, $devices 
 				$lastbackup = 'AND ($stime - (schedule * 86400)) - 3600 > lastbackup';
 			}
 
-			$devices = db_fetch_assoc("SELECT *
+			$sql = "SELECT *
 				FROM plugin_routerconfigs_devices
 				WHERE enabled = 'on'
 				$lastbackup
-				$lastattempt", false);
+				$lastattempt";
+			plugin_routerconfigs_log(__('DEBUG: ', 'routerconfigs') . str_replace("\n","",$sql));
+			$devices = db_fetch_assoc($sql, false);
 
 			$failed = array();
 			$passed = array();

--- a/functions.php
+++ b/functions.php
@@ -122,8 +122,8 @@ function plugin_routerconfigs_download($retry = false, $force = false, $devices 
 			if (sizeof($filter_devices)) {
 				$lastbackup =  'AND id IN (' . implode(',',$filter_devices) .')';
 			} elseif (!$force) {
-				$lastattempt = $retry ? 'AND $t - lastattempt > 18000' : '';
-				$lastbackup = 'AND ($stime - (schedule * 86400)) - 3600 > lastbackup';
+				$lastattempt = $retry ? "AND $t - lastattempt > 18000" : '';
+				$lastbackup = "AND ($stime - (schedule * 86400)) - 3600 > lastbackup";
 			}
 
 			$sql = "SELECT *

--- a/router-compare.php
+++ b/router-compare.php
@@ -45,23 +45,21 @@ $devices = db_fetch_assoc('SELECT id, directory, hostname
 	FROM plugin_routerconfigs_devices
 	ORDER BY hostname');
 
-if (empty($device1) || empty($device2)) {
+if (!is_numeric($device1) || !is_numeric($device2)) {
 	if (sizeof($devices)) {
 		$default = $devices[0]['id'];
 
-		if (!empty($device1)) {
-			if ($device1 == $default) {
-				$device2 = $default;
-			}
-		}else{
-			if ($device2 == $default) {
-				$device1 = $default;
-			}
+		if (!is_numeric($device1)) {
+			$device1 == $default;
+		}
+
+		if (!is_numeric($device2)) {
+			$device1 = $default;
 		}
 	}
 }
 
-if (!empty($device1)) {
+if (is_numeric($device1)) {
 	$files1 = db_fetch_assoc_prepared('SELECT id, directory, filename
 		FROM plugin_routerconfigs_backups
 		WHERE device = ?
@@ -70,7 +68,7 @@ if (!empty($device1)) {
 	$files1 = array();
 }
 
-if (!empty($device2)) {
+if (is_numeric($device2)) {
 	$files2 = db_fetch_assoc_prepared('SELECT id, directory, filename
 		FROM plugin_routerconfigs_backups
 		WHERE device = ? ORDER BY directory, filename DESC', array($device2));


### PR DESCRIPTION
Fix one bug (well lots) and introduce some more.  Changed the SQL filters to use double quotes for variable inclusion as it was preventing device selection for automated backups (also logs the SQL in debug now to be checked against).