### PR TITLE
Feature: Devices tab now has some filterable information

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: Fixed the poller spawn issue that was preventing automatic backups
 * issue: Fixed comparison device/file selection code
 * issue: Don't send email if nothing changed and checking for failures
+* feature: Filtering - Added to both Devices and Backups tab
 * feature: Backups - Now all use same code
 * feature: Backups - Manual now work the same way as automatic ones
 * feature: Backups - Manual can be done regardless of last attempt state

--- a/functions.php
+++ b/functions.php
@@ -122,7 +122,7 @@ function plugin_routerconfigs_download($retry = false, $force = false, $devices 
 				$lastbackup =  'AND id IN (' . implode(',',$filter_devices) .')';
 			} elseif (!$force) {
 				$lastattempt = $retry ? "AND $stime - lastattempt > 18000" : '';
-				$lastbackup = "AND ($stime - (schedule * 86400)) - 3600 > lastbackup";
+				$lastbackup = "AND ($stime - ($schedule * 86400)) - 3600 > lastbackup";
 			}
 
 			$sql = "SELECT *
@@ -1265,3 +1265,12 @@ class PHPTelnet {
 		return '';
 	}
 }
+
+function plugin_routerconfigs_date_from_time_with_na($time) {
+	return ($time > 0) ? date(CACTI_DATE_TIME_FORMAT, $time) : 'N/A';
+}
+
+function plugin_routerconfigs_date_from_time($time) {
+	return ($time > 0) ? date(CACTI_DATE_TIME_FORMAT, $time) : '';
+}
+

--- a/router-backups.php
+++ b/router-backups.php
@@ -70,7 +70,7 @@ function view_device_config() {
 		form_alternate_row();
 
 		print '<td><h2>' . __('Router Config for %s (%s)', $device['hostname'], $device['ipaddress'], 'routerconfigs');
-		print __('Backup from %s', date('M j Y H:i:s', $device['btime']), 'routerconfigs') . '<br>';
+		print __('Backup from %s', plugin_routerconfigs_date_from_time($device['btime']), 'routerconfigs') . '<br>';
 		print __('File: %s/%s', $device['directory'], $device['filename'], 'routerconfigs');
 		print '</h1><textarea rows=36 cols=120>';
 		print $device['config'];
@@ -134,11 +134,13 @@ function show_devices () {
 		$num_rows = get_request_var('rows');
 	}
 
-	get_filter_request_var('page');
+	if (get_filter_request_var('page') > 0) {
+		$page = get_request_var('page');
+	} else {
+		$page = 1;
+	}
 
 	load_current_session_value('page', 'sess_routerconfigs_backups_current_page', '1');
-
-	input_validate_input_number(get_request_var('page'));
 
 	$device = '';
 	if (isset_request_var('device')) {
@@ -335,14 +337,9 @@ function show_devices () {
 
 		$c = 0;
 		foreach ($result as $row) {
-			$lastchange = 'N/A';
-			if ($row['lastchange'] > 0) {
-				$lastchange = date('M j Y H:i:s', $row['lastchange']);
-			}
-			$lastbackup = 'N/A';
-			if ($row['btime'] > 1519049969) {
-				$lastbackup = date('M j Y H:i:s', $row['btime']);
-			}
+			$lastchange = plugin_routerconfigs_date_from_time_with_na($row['lastchange']);;
+			$lastbackup = plugin_routerconfigs_date_from_time_with_na($row['lastbackup']);;
+
 			form_alternate_row('line' . $row['id'], true);
 
 			form_selectable_cell(filter_value($row['hostname'], get_request_var('filter'), 'router-devices.php?action=edit&id=' . $row['device']), $row['device']);

--- a/router-devices.php
+++ b/router-devices.php
@@ -691,6 +691,9 @@ function show_devices() {
 
 
 	$display_text = array(
+		'nosort_actions' => array(
+			'display' => __('Actions', 'routerconfigs'),
+		),
 		'hostname' => array(
 			'display' => __('Hostname', 'routerconfigs'),
 			'align' => 'left',
@@ -820,14 +823,12 @@ function show_devices() {
 			$enabled = ($row['enabled'] == 'on' ? '<span class="deviceUp">' . __('Yes', 'routerconfigs') . '</span>' : '<span class="deviceDown">' . __('No', 'routerconfigs') . '</span>');
 
 
-			/* --- Move device actions to drop down  MJV
 			$cell = '<a class="hyperLink" href="telnet://' . $row['ipaddress'] .'"><img src="' . $config['url_path'] . 'plugins/routerconfigs/images/telnet.jpeg" style="height:14px;" alt="" title="' . __esc('Telnet', 'routerconfigs') . '"></a>';
 			if (file_exists($config['base_path'] . '/plugins/traceroute/tracenow.php')) {
-				$cell .= '<a class="hyperLink" href="' . htmlspecialchars($config['url_path'] . 'plugins/traceroute/tracenow.php?ip=' . $row['ipaddress']) .'"><img src="' . $config['url_path'] . 'plugins/routerconfigs/images/reddot.png" height=10 alt="" title="' . __esc('Trace Route', 'routerconfigs') . '"></a>';
+				$cell .= '<a class="hyperLink" href="' . htmlspecialchars($config['url_path'] . 'plugins/traceroute/tracenow.php?ip=' . $row['ipaddress']) .'"><img src="' . $config['url_path'] . 'plugins/routerconfigs/images/reddot.png" height=14 alt="" title="' . __esc('Trace Route', 'routerconfigs') . '"></a>';
 			}
-			$cell .= '<a class="linkEditMain" href="router-devices.php?action=viewdebug&id=' . $row['id'] . '"><img src="' . $config['url_path'] . 'plugins/routerconfigs/images/feedback.jpg" height=10 alt="" title="' . __esc('Router Debug Info', 'routerconfigs') . '"></a>';
+			$cell .= '<a class="linkEditMain" href="router-devices.php?action=viewdebug&id=' . $row['id'] . '"><img src="' . $config['url_path'] . 'plugins/routerconfigs/images/feedback.jpg" height=14 alt="" title="' . __esc('Router Debug Info', 'routerconfigs') . '"></a>';
 			form_selectable_cell($cell, $row['id'], '', 'width:1%;');
-			*/
 
 			form_selectable_cell(filter_value($row['hostname'], get_request_var('filter'), 'router-devices.php?&action=edit&id=' . $row['id']), $row['id'],'10%');
 			form_selectable_cell(filter_value($row['id'], get_request_var('filter'), 'router-devices.php?&action=edit&id=' . $row['id']), $row['id'], '1%', 'text-align:right');
@@ -846,7 +847,7 @@ function show_devices() {
 			form_end_row();
 		}
 	}else{
-		print "<tr class='even'><td colspan='12'>" . __('No Router Devices Found', 'routerconfigs') . "</td></tr>\n";
+		print "<tr class='even'><td colspan='13'>" . __('No Router Devices Found', 'routerconfigs') . "</td></tr>\n";
 	}
 
 	html_end_box(false);

--- a/router-devices.php
+++ b/router-devices.php
@@ -484,7 +484,7 @@ function devices_validate_vars() {
 			'default' => 'ASC',
 			'options' => array('options' => 'sanitize_search_string')
 			),
-		'device_type' => array(
+		'devicetype' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
@@ -524,18 +524,18 @@ function show_devices() {
 	load_current_session_value('page', 'sess_routerconfigs_devices_current_page', '1');
 	$num_rows = 30;
 
-	$device_type = '';
-	if (isset_request_var('device_type')) {
-		$device_type = get_filter_request_var('device_type');
+	$devicetype = '';
+	if (isset_request_var('devicetype')) {
+		$devicetype = get_filter_request_var('devicetype');
 
-		if (isset($_SESSION['routerconfigs_devices_device_type']) && $_SESSION['routerconfigs_devices_device_type'] != $device_type) {
+		if (isset($_SESSION['routerconfigs_devices_devicetype']) && $_SESSION['routerconfigs_devices_devicetype'] != $devicetype) {
 			$page = 1;
 			set_request_var('page','1');
 		}
 
-		$_SESSION['routerconfigs_devices_device_type'] = $device_type;
-	} else if (isset($_SESSION['routerconfigs_devices_device_type']) && $_SESSION['routerconfigs_devices_device_type'] != '') {
-		$device = $_SESSION['routerconfigs_devices_device_type'];
+		$_SESSION['routerconfigs_devices_devicetype'] = $devicetype;
+	} else if (isset($_SESSION['routerconfigs_devices_devicetype']) && $_SESSION['routerconfigs_devices_devicetype'] != '') {
+		$devicetype = $_SESSION['routerconfigs_devices_devicetype'];
 	}
 
 	$account = '';
@@ -549,38 +549,37 @@ function show_devices() {
 
 		$_SESSION['routerconfigs_devices_account'] = $account;
 	} else if (isset($_SESSION['routerconfigs_devices_account']) && $_SESSION['routerconfigs_devices_account'] != '') {
-		$device = $_SESSION['routerconfigs_devices_account'];
+		$account = $_SESSION['routerconfigs_devices_account'];
 	}
 
 	$sqlwhere = '';
-	$sqlwherevar = array();
-
 	if ($account > 0) {
-		$sqlwhere .= ($sqlwhere == ''?'WHERE':'AND') . ' account = ?';
-		array_push($sqlwherevar, $account);
+		$sqlwhere .= ($sqlwhere == ''?'WHERE':'AND') . ' account = ' . $account;
 	}
 
-	if ($device_type > 0) {
-		$sqlwhere .= ($sqlwhere == ''?'WHERE':'AND') . ' device_type = ?';
-		array_push($sqlwherevar, $device_type);
+	if ($devicetype > 0) {
+		$sqlwhere .= ($sqlwhere == ''?'WHERE':'AND') . ' devicetype = ' . $devicetype;
 	}
 
-	$total_rows = db_fetch_cell_prepared('SELECT COUNT(*) FROM plugin_routerconfigs_devices ' . $sqlwhere, $sqlwherevar);
+	$total_rows = db_fetch_cell('SELECT COUNT(*) FROM plugin_routerconfigs_devices ' . $sqlwhere);
 
-	$sql = 'SELECT * FROM plugin_routerconfigs_devices '. $sqlwhere . ' ORDER BY ? ? LIMIT ' . ($num_rows*($page-1)) . ', ' . $num_rows;
-	$sqlvar = array();
-	if ($sqlwhere > '') {
-		array_merge($sqlvar, $sqlwherevar);
-	}
-	array_push($sqlvar, get_request_var('sort_column'),  get_request_var('sort_direction'));
-	$result = db_fetch_assoc_prepared($sql, $sqlvar);
+	$sort_column = get_request_var('sort_column');
+	$sort_direction = get_request_var('sort_direction');
+	$sort_limit = $num_rows*($page-1);
+
+	$sql = "SELECT * FROM plugin_routerconfigs_devices
+		$sqlwhere
+		ORDER BY $sort_column $sort_direction
+		LIMIT $sort_limit, $num_rows";
+
+	$result = db_fetch_assoc($sql);
 
 	?>
 	<script type='text/javascript'>
 
 	function applyFilter() {
 		strURL  = 'router-devices.php?header=false'
-		strURL += '&device_type=' + $('#device_type').val();
+		strURL += '&devicetype=' + $('#devicetype').val();
 		strURL += '&account=' + $('#account').val();
 		strURL += '&rows=' + $('#rows').val();
 		strURL += '&filter=' + $('#filter').val();
@@ -593,7 +592,7 @@ function show_devices() {
 	}
 
 	$(function() {
-		$('#rows, #device_type, #account, #filter').change(function() {
+		$('#rows, #devicetype, #account, #filter').change(function() {
 			applyFilter();
 		});
 
@@ -627,14 +626,14 @@ function show_devices() {
 						<?php print __('Device Type','routerconfigs');?>
 					</td>
 					<td>
-						<select id='device_type'>
-							<option value='-1'<?php if (get_request_var('device_type') == '-1') {?> selected<?php }?>><?php print __('Any','routerconfigs');?></option>
+						<select id='devicetype'>
+							<option value='-1'<?php if (get_request_var('devicetype') == '-1') {?> selected<?php }?>><?php print __('Any','routerconfigs');?></option>
 							<?php
-							$device_types = db_fetch_assoc('SELECT id, name FROM plugin_routerconfigs_devicetypes ORDER BY name');
+							$devicetypes = db_fetch_assoc('SELECT id, name FROM plugin_routerconfigs_devicetypes ORDER BY name');
 
-							if (sizeof($device_types)) {
-								foreach ($device_types as $device_type) {
-									print "<option value='" . $device_type['id'] . "'"; if (get_request_var('device_type') == $device_type['id']) { print ' selected'; } print '>' . htmlspecialchars($device_type['name']) . "</option>\n";
+							if (sizeof($devicetypes)) {
+								foreach ($devicetypes as $devicetype) {
+									print "<option value='" . $devicetype['id'] . "'"; if (get_request_var('devicetype') == $devicetype['id']) { print ' selected'; } print '>' . htmlspecialchars($devicetype['name']) . "</option>\n";
 								}
 							}
 							?>
@@ -715,7 +714,7 @@ function show_devices() {
 			'sort' => 'ASC',
 			'tip' => __('The last Backup time of the device', 'routerconfigs')
 		),
-		'device_type' => array(
+		'devicetype' => array(
 			'display' => __('Device Type', 'routerconfigs'),
 			'align' => 'left',
 			'sort' => 'ASC',
@@ -754,8 +753,6 @@ function show_devices() {
 			'tip' => __('The directory of the stored device backups', 'routerconfigs')
 		),
 	);
-
-	$url_page_select = get_page_list(get_request_var('page'), MAX_DISPLAY_PAGES, $num_rows, $total_rows, 'router-devices.php?' . ($account != '' ? 'account=' . $account:''));
 
 	form_start('router-devices.php', 'chk');
 

--- a/router-devices.php
+++ b/router-devices.php
@@ -846,7 +846,7 @@ function show_devices() {
 			form_end_row();
 		}
 	}else{
-		print "<tr class='even'><td colspan='10'>" . __('No Router Devices Found', 'routerconfigs') . "</td></tr>\n";
+		print "<tr class='even'><td colspan='12'>" . __('No Router Devices Found', 'routerconfigs') . "</td></tr>\n";
 	}
 
 	html_end_box(false);


### PR DESCRIPTION
This update brings in more UI changes to help with analysis of when a backup last occurred.  Existing "Last Backup", "Last Changed" columns are now labelled "Date Backup" "Date Changed" and a new column "Last Backup" will show:

Value | Meaning
--- | ---
Today | A backup has occurred since midnight (00:00hrs / 12am)
Yesterday | A backup has occurred between midnight the day before and Today
This Week | A backup has occurred since the first day of this week
This Month | A backup has occurred since the first day of this month,
Last Year | A backup has occurred within the last year
Long, Long Ago | A backup has occurred but it's so long ago is it really worth it?
Never: | Come on, get one going!

Also updated the plugins date/time stamps that are visually displayed (email or webpage) to use the Cacti standard format to bring it inline with Cacti itself.