### PR TITLE
Update to v1.3.1

### DIFF
--- a/INFO
+++ b/INFO
@@ -1,6 +1,6 @@
 [info]
 name = routerconfigs
-version = 1.3
+version = 1.3.1
 longname = Router Configs
 author = The Cacti Group
 email = 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: Number of devices display in manual mode was always 0
 * issue: Echo'd tftp command would sometimes cause premature termination
 * issue: Only send destination filename and server once
+* issue: Device inclusion could be duplicated causing more than one download
+* issue: Correct spelling of 'socked'
+* issue: Include successful devices in email if using --force option.
 
 --- 1.3 ---
 * feature: Completely rejigged PHPSsh/PHPTelnet to use base PHPConnection class
@@ -56,8 +59,6 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: TFTP bytes copied would not be picked up as a transfer completion
 * issue: Midnight full download would not trigger without --retry cause no full downloads
 * issue: Default sort column was not a valid field
-* issue: Device inclusion could be duplicated causing more than one download
-* issue: Correct spelling of 'socked'
 
 --- 1.2 ---
 * issue: Correct most config comparision code

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: Correct spelling of 'socked'
 * issue: Include successful devices in email if using --force option.
 * issue: Correct wording during object creation, it's not connecting and needs classType
+* issue: Suppress PHP warning when SSH connection fails
 
 --- 1.3 ---
 * feature: Completely rejigged PHPSsh/PHPTelnet to use base PHPConnection class
@@ -60,7 +61,6 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: TFTP bytes copied would not be picked up as a transfer completion
 * issue: Midnight full download would not trigger without --retry cause no full downloads
 * issue: Default sort column was not a valid field
-* issue: Suppress PHP warning when SSH connection fails
 
 --- 1.2 ---
 * issue: Correct most config comparision code

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ On other operating systems, or for CentOS 7, you will have to find equivalent in
 Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.  If you find a first search the Cacti forums for a solution before creating an issue in GitHub.
 
 ## ChangeLog
+--- 1.3.1 --
+* feature: Parameters can now be specified with values separated by space ( ) or equals sign (=)
+* feature: Debug Buffer can be turned on via command line
+* issue: Number of devices display in manual mode was always 0
+* issue: Echo'd tftp command would sometimes cause premature termination
+* issue: Only send destination filename and server once
+
 --- 1.3 ---
 * feature: Completely rejigged PHPSsh/PHPTelnet to use base PHPConnection class
 * feature: Moved RouterConfig settings to their own tab as more have been added

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: TFTP bytes copied would not be picked up as a transfer completion
 * issue: Midnight full download would not trigger without --retry cause no full downloads
 * issue: Default sort column was not a valid field
+* issue: Device inclusion could be duplicated causing more than one download
+* issue: Correct spelling of 'socked'
 
 --- 1.2 ---
 * issue: Correct most config comparision code

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: TFTP bytes copied would not be picked up as a transfer completion
 * issue: Midnight full download would not trigger without --retry cause no full downloads
 * issue: Default sort column was not a valid field
+* issue: Suppress PHP warning when SSH connection fails
 
 --- 1.2 ---
 * issue: Correct most config comparision code

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: Device inclusion could be duplicated causing more than one download
 * issue: Correct spelling of 'socked'
 * issue: Include successful devices in email if using --force option.
+* issue: Correct wording during object creation, it's not connecting and needs classType
 
 --- 1.3 ---
 * feature: Completely rejigged PHPSsh/PHPTelnet to use base PHPConnection class

--- a/functions.php
+++ b/functions.php
@@ -176,9 +176,9 @@ function plugin_routerconfigs_download(bool $retry = false, bool $force = false,
 				plugin_routerconfigs_message($message, __('%s devices backed up successfully.', $success, 'routerconfigs'));
 				plugin_routerconfigs_message($message, __('%s devices failed to backup.', $cfailed, 'routerconfigs'));
 
-				if (!empty($passed) && $retry) {
-					plugin_routerconfigs_message($message, __('These devices have now backuped', 'routerconfigs'));
-					plugin_routerconfigs_message($message, __('-------------------------------', 'routerconfigs'));
+				if (!empty($passed) && ($retry || $force)) {
+					plugin_routerconfigs_message($message, __('These devices have been backed up', 'routerconfigs'));
+					plugin_routerconfigs_message($message, __('---------------------------------', 'routerconfigs'));
 					foreach ($passed as $f) {
 						plugin_routerconfigs_message($message, $f['hostname']);
 					}

--- a/functions.php
+++ b/functions.php
@@ -86,7 +86,7 @@ function plugin_routerconfigs_backtrace($skip = 1) {
 	}
 }
 
-function plugin_routerconfigs_download(bool $retry = false, bool $force = false, array $devices = array(), bool $buffer_debug = false) {
+function plugin_routerconfigs_download($retry = false, $force = false, $devices = array(), $buffer_debug = false) {
 	ini_set('max_execution_time', '0');
 	ini_set('memory_limit', '256M');
 
@@ -297,7 +297,7 @@ function plugin_routerconfigs_stop($force_stop) {
 	exit();
 }
 
-function plugin_routerconfigs_download_config(array $device, bool $buffer_debug = false) {
+function plugin_routerconfigs_download_config($device, $buffer_debug = false) {
 	$info = plugin_routerconfigs_retrieve_account($device['id']);
 	$dir  = $device['directory'];
 	$ip   = $device['ipaddress'];

--- a/functions.php
+++ b/functions.php
@@ -860,7 +860,7 @@ abstract class PHPConnection {
 		$this->isEnabeld = false;
 		$this->setServerDetails();
 
-		$this->Log("DEBUG: SSH->Connect(Server: $this->server, User: $this->user, Password: $this->pw1_text, Enablepw: $this->pw2_text, Devicetype: ".json_encode($this->devicetype));
+		$this->Log("DEBUG: Creating $classType(Server: $this->server, User: $this->user, Password: $this->pw1_text, Enablepw: $this->pw2_text, Devicetype: ".json_encode($this->devicetype));
 	}
 
 	protected function setServerDetails() {

--- a/functions.php
+++ b/functions.php
@@ -1102,7 +1102,7 @@ class PHPSsh extends PHPConnection {
 		}
 
 		if (strlen($this->ip)) {
-			if(!($this->connection = ssh2_connect($this->server, 22))){
+			if(!($this->connection = @ssh2_connect($this->server, 22))){
 				$rv=1;
 			} else {
 				// try to authenticate

--- a/functions.php
+++ b/functions.php
@@ -1223,7 +1223,7 @@ class PHPTelnet extends PHPConnection {
 		$this->Disconnect();
 
 		if (strlen($this->ip)) {
-			$this->Log("Attempting to open socked to $this->ip:23");
+			$this->Log("Attempting to open socket to $this->ip:23");
 			if (@$this->stream = fsockopen($this->ip, 23)) {
 				@fputs($this->stream, $this->conn1);
 				$this->Sleep();

--- a/functions.php
+++ b/functions.php
@@ -957,7 +957,7 @@ abstract class PHPConnection {
 		}
 
 		$this->Log('Process is now ' . ( $this->IsEnabled() ? '' : 'NOT ') . 'enabled');
-		return $this->IsEnabled;
+		return $this->IsEnabled();
 	}
 
 

--- a/router-download.php
+++ b/router-download.php
@@ -85,6 +85,7 @@ foreach($options as $arg => $value) {
 					if (!is_numeric($deviceId)) {
 						routerconfigs_fail(EXIT_NONNUM, $deviceId);
 					}
+					//echo "Adding device $deviceId\n";
 					$devices[] = $deviceId;
 				}
 			}
@@ -271,16 +272,23 @@ function routerconfigs_getopts_find(string $arg, array $options) {
 				unset($found['result']);
 			}
 
-			if (strlen($arg) >= strlen($option['text']) &&
-			    substr($option['text'],0,strlen($arg)) == $arg) {
-				$separator_pos = strlen($option['text']) - 1;
+			$length_arg = strlen($arg);
+			$length_txt = strlen($option['text']);
+			$substr_txt = substr($arg,0,$length_txt);
+			//echo sprintf("%3d arg, %3d txt, %15s = %s\n", $length_arg, $length_txt, $option['text'], $substr_txt);
+			if ($length_arg > $length_txt && $substr_txt == $option['text']) {
+				$separator_pos = strlen($option['text']);
 				$separator = $arg[$separator_pos];
+				//echo "$arg $separator found\n";
 				if ($separator == '=') {
 					$found = $option;
 					$separator_pos++;
-					if ($separator_pos < strlen($arg) - 1) {
-						$found['result'] = substr($separator, $separator_pos);
+					if ($separator_pos < strlen($arg)) {
+						$substr_txt = substr($arg, $separator_pos);
+						//echo "Setting $substr_txt\n";
+						$found['result'] = $substr_txt;
 					} else {
+						//echo "Unsetting result\n";
 						unset($found['result']);
 					}
 				}

--- a/router-download.php
+++ b/router-download.php
@@ -118,6 +118,7 @@ foreach($options as $arg => $value) {
 	}
 }
 
+$devices = array_unique($devices);
 plugin_routerconfigs_download($retryMode, $force, $devices, $debugBuffer);
 exit(EXIT_NORMAL);
 

--- a/router-download.php
+++ b/router-download.php
@@ -27,6 +27,12 @@ if (!isset($_SERVER['argv'][0]) || isset($_SERVER['REQUEST_METHOD'])  || isset($
 	die('<br><strong>This script is only meant to run at the command line.</strong>');
 }
 
+routerconfigs_define_exit('EXIT_UNKNOWN',-1, "ERROR: Failed due to unknown reason\n");
+routerconfigs_define_exit('EXIT_NORMAL',  0, "");
+routerconfigs_define_exit('EXIT_ARGERR',  1, "ERROR: Invalid Argument (%s)\n\n");
+routerconfigs_define_exit('EXIT_NONNUM',  2, "ERROR: Argument is not numeric (%s)\n\n");
+routerconfigs_define_exit('EXIT_ARGMIS',  3, "ERROR: Argument requires value (%s)\n\n");
+
 /* We are not talking to the browser */
 $no_http_headers = true;
 
@@ -37,49 +43,296 @@ if (strpos($dir, 'plugins') !== false) {
 	chdir('../../');
 }
 
+$shortOpts = 'VvH:h:DdBbRrFf';
+$longOpts  = array(
+	'device:',
+	'devices:',
+	'debug',
+	'debug-buffer',
+	'force',
+	'version',
+	'help'
+);
+
+$options = routerconfigs_getopts($shortOpts, $longOpts, $remaining);
+
 include('./include/global.php');
 include_once($config['base_path'] . '/plugins/routerconfigs/functions.php');
 
 error_reporting(E_ALL ^ E_DEPRECATED);
-$parms = $_SERVER['argv'];
-array_shift($parms);
 
 /* setup defaults */
 $retryMode = false;
+$debugBuffer = false;
 $debug = false;
 $force = false;
-$devices = null;
+$devices = array();
 
-if (sizeof($parms)) {
+foreach($options as $arg => $value) {
+	switch ($arg) {
+		case 'h':
+		case 'host':
+		case 'hosts':
+		case 'device':
+		case 'devices':
+			if (!is_array($value)) {
+				$value = array($value);
+			}
 
-	foreach($parms as $parameter) {
-		if (strpos($parameter, '=')) {
-			list($arg, $value) = explode('=', $parameter);
-		} else {
-			$arg = $parameter;
-			$value = '';
-		}
-
-		switch ($arg) {
-		case '-d':
-		case '--debug':
+			foreach ($value as $deviceId) {
+				$deviceIds = explode(',',$deviceId);
+				foreach ($deviceIds as $deviceId) {
+					if (!is_numeric($deviceId)) {
+						routerconfigs_fail(EXIT_NONNUM, $deviceId);
+					}
+					$devices[] = $deviceId;
+				}
+			}
+			break;
+		case 'd':
+		case 'debug':
 			$debug = true;
 			break;
-		case '--devices':
-			$devices = $value;
+		case 'b':
+		case 'debug-buffer':
+			$debug = true;
+			$debugBuffer = true;
 			break;
-		case '--force':
+		case 'f':
+		case 'force':
 			$force = true;
 			break;
-		case '--retry':
+		case 'q':
+		case 'quiet':
+			$debug = false;
+			$debugBuffer = false;
+			$quiet = true;
+			break;
+		case 'r':
+		case 'retry':
 			$retryMode = true;
 			break;
 		default:
-			plugin_routerconfigs_log('ERROR: Invalid Argument: (' . $arg . ')');
-			exit(1);
+			routerconfigs_fail(EXIT_ARGERR, $arg, true);
+	}
+}
+
+plugin_routerconfigs_download($retryMode, $force, $devices, $debugBuffer);
+exit(EXIT_NORMAL);
+
+function routerconfigs_fail($exit_value,$args = array(),$display_help = 0) {
+	global $quiet,$fail_msg;
+
+	if (!$quiet) {
+		if (!isset($args)) {
+			$args = array();
+		} else if (!is_array($args)) {
+			$args = array($args);
+		}
+
+		if (!array_key_exists($exit_value,$fail_msg)) {
+			$format = $fail_msg[EXIT_UNKNOWN];
+		} else {
+			$format = $fail_msg[$exit_value];
+		}
+		call_user_func_array('printf', array_merge((array)$format, $args));
+
+		if ($display_help) {
+//			display_help();
+		}
+	}
+
+	exit($exit_value);
+}
+
+function routerconfigs_define_exit($name, $value, $text) {
+	global $fail_msg;
+
+	if (!isset($fail_msg)) {
+		$fail_msg = array();
+	}
+
+	define($name,$value);
+	$fail_msg[$name] = $text;
+	$fail_msg[$value] = $text;
+}
+
+function routerconfigs_getopts($short, $long, &$remaining = null) {
+	$remaining = '';
+	$argv = $_SERVER['argv'];
+	$argc = $_SERVER['argc'];
+	$result = array();
+
+	$options = array();
+	routerconfigs_getopts_short($options, $short);
+	routerconfigs_getopts_long($options, $long);
+
+	$ignoreOptions = false;
+	for ($loop = 1; $loop < $argc; $loop++) {
+		$name = null;
+		$value = null;
+
+		$arg = $argv[$loop];
+		if ($arg == '--') {
+			$ignoreOptions = true;
+		} else {
+			$option = $ignoreOptions ? null : routerconfigs_getopts_find($arg, $options);
+			if ($option != null)
+			{
+				if ($option['value']) {
+					if (!isset($option['result']) && $loop < $argc -1) {
+						$option2 = routerconfigs_getopts_find($argv[$loop+1], $options);
+						if ($option2 == null ) {
+							$option['result'] = $argv[$loop+1];
+							$loop++;
+						}
+					}
+
+					if (!$option['optional'] && !isset($option['result'])) {
+						routerconfigs_fail(EXIT_ARGMIS,$option['text']);
+					}
+				}
+
+				$name = $option['text'];
+				$value = isset($option['result']) ? $option['result'] : '';
+				if (array_key_exists($name, $result)) {
+					$result_val = $result[$name];
+					if (!is_array($result_val)) {
+						$result_val = array($result_val);
+					}
+
+					$result_val[] = $value;
+				} else {
+					$result_val = $value;
+				}
+
+				$result[$name] = $result_val;
+			} else {
+				$remaining .= (strlen($remaining)?' ':'') . $arg;
+			}
+		}
+	}
+
+	return $result;
+}
+
+function routerconfigs_getopts_long(array &$options, array &$long) {
+	if (isset($long)) {
+		if (!is_array($long)) {
+			$long = array($long);
+		}
+
+		if (sizeof($long)) {
+			$index = 0;
+			foreach ($long as $long_text) {
+				$long_text = trim($long_text);
+				if (strlen($long_text) == 0 || !preg_match("~[A-Za-z0-9:\-]~", $long_text)) {
+					routerconfigs_fail(EXIT_OPTERR,$long_text);
+				}
+
+				$long_val  = routerconfigs_checkopt_string('value',$long_text);
+				$long_opt  = routerconfigs_checkopt_string('optional',$long_text);
+
+
+				if ($long_opt) $long_text = substr($long_text, 0, -1);
+
+				routerconfigs_addopt($options, count($options), $long_text, $long_val, $long_opt);
+			}
 		}
 	}
 }
 
-plugin_routerconfigs_download($retryMode, $force, $devices);
+function routerconfigs_getopts_short(array &$options, $short) {
+	if (!preg_match("~[A-Za-z0-9:]~", $short)) {
+		routerconfigs_fail(EXIT_OPTERR,$short);
+	}
 
+	$options = array();
+	for ($loop = 0; $loop < strlen($short); $loop++) {
+		$short_text = $short[$loop];
+		$short_val = routerconfigs_checkopt('value', $short, $loop);
+		$short_opt = routerconfigs_checkopt('value', $short, $loop);
+
+		routerconfigs_addopt($options, $loop, $short_text, $short_val, $short_opt);
+	}
+}
+
+function routerconfigs_getopts_find(string $arg, array $options) {
+	$found = null;
+
+	if (strlen($arg) && $arg[0] == '-') {
+		while (strlen($arg) && $arg[0] == '-') {
+			$arg = substr($arg,1);
+		}
+
+		foreach ($options as $option) {
+			if ($arg == $option['text']) {
+				$found = $option;
+				unset($found['result']);
+			}
+
+			if (strlen($arg) >= strlen($option['text']) &&
+			    substr($option['text'],0,strlen($arg)) == $arg) {
+				$separator_pos = strlen($option['text']) - 1;
+				$separator = $arg[$separator_pos];
+				if ($separator == '=') {
+					$found = $option;
+					$separator_pos++;
+					if ($separator_pos < strlen($arg) - 1) {
+						$found['result'] = substr($separator, $separator_pos);
+					} else {
+						unset($found['result']);
+					}
+				}
+			}
+		}
+	}
+	//echo sprintf("routerconfigs_getopts_find('%s', options()) return %s%s\n",
+	//	$arg,
+	//	$found == null ? '<null>' : str_replace("\n","",var_export($found, true)),
+	//	$found == null ? '' : ' '.(isset($found['result']) ? str_replace("\n","",var_export($found,true)) : '<null>'));
+	return $found;
+}
+
+function routerconfigs_addopt(array &$options, $index, $text, $val, $opt) {
+	$option = array(
+		'text' => $text,
+		'value' => $val,
+		'optional' => $opt
+	);
+
+	//echo sprintf("Adding option %2s (%3d%s%s)\n", $text, $index, ($val?' hasValue':''), ($opt?' hasOptional':''));
+	$options[] = $option;
+}
+
+function routerconfigs_checkopt(string $label, string $short, &$index) {
+	$result = false;
+	$colon = '<unset>';
+
+	if ($index < strlen($short) - 1) {
+		$colon = $short[$index+1];
+		if ($colon == ':') {
+			$index++;
+			$result = true;
+		}
+	}
+	//echo sprintf("%15s routerconfigs_checkopt('%s', %3d) returned %-5s (%s)\n", $label, $short, $index, $result ? 'Yes' : 'No', $colon);
+	return $result;
+}
+
+function routerconfigs_checkopt_string($label, string &$text) {
+	$result = false;
+	$output = $text;
+	$colon = '<unset>';
+
+	if (strlen($text) > 1) {
+		$colon = $text[strlen($text) - 1];
+		if ($colon == ':') {
+			$result = true;
+			$output = substr($text, 0, - 1);
+		}
+	}
+	//echo sprintf("%15s routerconfigs_checkopt_string('%s returned %-5s (%s - %s)\n", $label, $text . '\')', $result ? 'Yes' : 'No', $colon, $output);
+	$text = $output;
+	return $result;
+}


### PR DESCRIPTION
I've been testing this against my devices and @chris-technicate has been helping against his too. I think I've narrowed down quite a few minor bugs etc so I'll be updating it to 1.3.1 with the following updates:

- feature: Parameters can now be specified with values separated by space ( ) or equals sign (=)
- feature: Debug Buffer can be turned on via command line
- issue: Number of devices display in manual mode was always 0
- issue: Echo'd tftp command would sometimes cause premature termination
- issue: Only send destination filename and server once
- issue: Device inclusion could be duplicated causing more than one download
- issue: Correct spelling of 'socked'
- issue: Include successful devices in email if using --force option.
- issue: Correct wording during object creation, it's not connecting and needs classType
- issue: Suppress PHP warning when SSH connection fails