### PR TITLE
Update to v1.3.2

### DIFF
--- a/INFO
+++ b/INFO
@@ -1,9 +1,9 @@
 [info]
 name = routerconfigs
-version = 1.3.1
+version = 1.3.2
 longname = Router Configs
 author = The Cacti Group
 email = 
 homepage = http://www.cacti.net
-compat = 1.1.1
+compat = 1.1.36
 capabilities = online_view:1, online_mgmt:1, offline_view:0, offline_mgmt:0, remote_collect:0

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 ## ChangeLog
 --- 1.3.2 ---
 * feature: Add two new options, email name and download hour
-* feature: Expanded editing area of email to, so email addreses can be seen
-* issue: Another attempt to correct automatic vs mnaual backups
+* feature: Expanded editing area of email to, so email addresses can be seen
+* issue: Another attempt to correct automatic vs manual backups
 * issue: Prevent 0/0 emails from being generated
 * issue: Prevent endless loop when connecting via telnet and not enabled
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,13 @@ On other operating systems, or for CentOS 7, you will have to find equivalent in
 Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.  If you find a first search the Cacti forums for a solution before creating an issue in GitHub.
 
 ## ChangeLog
---- 1.3.1 --
+--- 1.3.2 ---
+* feature: Add two new options, email name and download hour
+* feature: Expanded editing area of email to, so email addreses can be seen
+* issue: Another attempt to correct automatic vs mnaual backups
+* issue: Prevent 0/0 emails from being generated
+
+--- 1.3.1 ---
 * feature: Parameters can now be specified with values separated by space ( ) or equals sign (=)
 * feature: Debug Buffer can be turned on via command line
 * issue: Number of devices display in manual mode was always 0

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * feature: Expanded editing area of email to, so email addreses can be seen
 * issue: Another attempt to correct automatic vs mnaual backups
 * issue: Prevent 0/0 emails from being generated
+* issue: Prevent endless loop when connecting via telnet and not enabled
 
 --- 1.3.1 ---
 * feature: Parameters can now be specified with values separated by space ( ) or equals sign (=)

--- a/functions.php
+++ b/functions.php
@@ -954,9 +954,9 @@ abstract class PHPConnection {
 							$this->Log('DEBUG: Ok we are in enabled mode');
 						}
 					}
-				}
 
-				$x++;
+					$x++;
+				}
 			}
 		}
 

--- a/functions.php
+++ b/functions.php
@@ -99,7 +99,11 @@ function plugin_routerconfigs_download($retry = false, $force = false, $devices 
 		$filter_devices = $devices;
 		plugin_routerconfigs_log(__('NOTICE: Starting manual backup of %s devices',sizeof($filter_devices),'routerconfigs'));
 	} else {
-		plugin_routerconfigs_log(__('NOTICE: Starting automatic backup','routerconfigs'));
+		if ($retry) {
+			plugin_routerconfigs_log(__('NOTICE: Starting automatic retry','routerconfigs'));
+		} else {
+			plugin_routerconfigs_log(__('NOTICE: Starting automatic backup','routerconfigs'));
+		}
 		plugin_routerconfigs_start($force);
 	}
 
@@ -158,54 +162,54 @@ function plugin_routerconfigs_download($retry = false, $force = false, $devices 
 						$failed[] = array('hostname' => $device['hostname'], 'lasterror' => $fmsg);
 					}
 				}
-			}
 
-			$success = count($devices) - count($failed);
-			$cfailed = count($failed);
-			$totalsecs = time() - $stime;
+				$success = count($devices) - count($failed);
+				$cfailed = count($failed);
+				$totalsecs = time() - $stime;
 
-			$notice_level = 'NOTICE:';
-			if ($cfailed > 0) {
-				$notice_level = 'WARNING:';
-			}
-
-			plugin_routerconfigs_log("$notice_level $success Devices Backed Up and $cfailed Devices Failed in $totalsecs seconds");
-
-			if ($success != 0 || $cfailed != 0 || $retry != true) {
-				/* print out failures */
-				plugin_routerconfigs_message($message, __('%s devices backed up successfully.', $success, 'routerconfigs'));
-				plugin_routerconfigs_message($message, __('%s devices failed to backup.', $cfailed, 'routerconfigs'));
-
-				if (!empty($passed) && ($retry || $force)) {
-					plugin_routerconfigs_message($message, __('These devices have been backed up', 'routerconfigs'));
-					plugin_routerconfigs_message($message, __('---------------------------------', 'routerconfigs'));
-					foreach ($passed as $f) {
-						plugin_routerconfigs_message($message, $f['hostname']);
-					}
+				$notice_level = 'NOTICE:';
+				if ($cfailed > 0) {
+					$notice_level = 'WARNING:';
 				}
 
-				if (!empty($failed)) {
-					plugin_routerconfigs_message($message, __('These devices failed to backup', 'routerconfigs'));
-					plugin_routerconfigs_message($message, __('------------------------------', 'routerconfigs'));
-					foreach ($failed as $f) {
-						plugin_routerconfigs_message($message, $f['hostname'] . ' - ' . $f['lasterror']);
-					}
-				}
+				plugin_routerconfigs_log("$notice_level $success Devices Backed Up and $cfailed Devices Failed in $totalsecs seconds");
 
-				$from_email = read_config_option('settings_from_email');
-				$from_name  = read_config_option('settings_from_name');
-				$to         = read_config_option('routerconfigs_email');
+				if ($success != 0 || $cfailed != 0 || $retry != true) {
+					/* print out failures */
+					plugin_routerconfigs_message($message, __('%s devices backed up successfully.', $success, 'routerconfigs'));
+					plugin_routerconfigs_message($message, __('%s devices failed to backup.', $cfailed, 'routerconfigs'));
 
-				if ($to != '' && $from_email != '') {
-					if ($from_name == '') {
-						$from_name = __('Config Backups', 'routerconfigs');
+					if (!empty($passed) && ($retry || $force)) {
+						plugin_routerconfigs_message($message, __('These devices have been backed up', 'routerconfigs'));
+						plugin_routerconfigs_message($message, __('---------------------------------', 'routerconfigs'));
+						foreach ($passed as $f) {
+							plugin_routerconfigs_message($message, $f['hostname']);
+						}
 					}
 
-					$from[0] = $from_email;
-					$from[1] = $from_name;
-					$subject = __('Network Device Configuration Backups%s', ($retry?__(' - Reattempt','routerconfigs') : ''), 'routerconfigs');
+					if (!empty($failed)) {
+						plugin_routerconfigs_message($message, __('These devices failed to backup', 'routerconfigs'));
+						plugin_routerconfigs_message($message, __('------------------------------', 'routerconfigs'));
+						foreach ($failed as $f) {
+							plugin_routerconfigs_message($message, $f['hostname'] . ' - ' . $f['lasterror']);
+						}
+					}
 
-					send_mail($to, $from, __('Network Device Configuration Backups - Reattempt', 'routerconfigs'), $message, $filename = '', $headers = '', $html = true);
+					$from_email = read_config_option('routerconfigs_from');
+					$from_name  = read_config_option('routerconfigs_name');
+					$to         = read_config_option('routerconfigs_email');
+
+					if ($to != '' && $from_email != '') {
+						if ($from_name == '') {
+							$from_name = __('Config Backups', 'routerconfigs');
+						}
+
+						$from[0] = $from_email;
+						$from[1] = $from_name;
+						$subject = __('Network Device Configuration Backups%s', ($retry?__(' - Reattempt','routerconfigs') : ''), 'routerconfigs');
+
+						send_mail($to, $from, __('Network Device Configuration Backups - Reattempt', 'routerconfigs'), $message, $filename = '', $headers = '', $html = true);
+					}
 				}
 			}
 			/* remove old backups */

--- a/router-backups.php
+++ b/router-backups.php
@@ -161,7 +161,7 @@ function show_devices () {
 		$sqlwhere = 'WHERE prb.device = ' . $device;
 	}
 	$sql = 'SELECT prd.hostname, prd.ipaddress, prb.id, prb.username, prb.lastchange,
-		prb.btime, prb.device, prb.directory, prb.filename
+		prb.btime, prb.device, prb.directory, prb.filename, prd.lastbackup,
 		FROM plugin_routerconfigs_devices AS prd
 		INNER JOIN plugin_routerconfigs_backups AS prb
 		ON prd.id = prb.device

--- a/router-backups.php
+++ b/router-backups.php
@@ -161,7 +161,7 @@ function show_devices () {
 		$sqlwhere = 'WHERE prb.device = ' . $device;
 	}
 	$sql = 'SELECT prd.hostname, prd.ipaddress, prb.id, prb.username, prb.lastchange,
-		prb.btime, prb.device, prb.directory, prb.filename, prd.lastbackup,
+		prb.btime, prb.device, prb.directory, prb.filename, prd.lastbackup
 		FROM plugin_routerconfigs_devices AS prd
 		INNER JOIN plugin_routerconfigs_backups AS prb
 		ON prd.id = prb.device

--- a/router-devices.php
+++ b/router-devices.php
@@ -316,8 +316,7 @@ function actions_devices() {
 				' --devices=' . implode(',',$device_array);
 
 			plugin_routerconfigs_log(__("DEBUG: Executing manual backup using '%s' with arguments '%s'",$command_string,$extra_args,'routerconfigs'));
-			exec_background($command_string, $extra_args);
-			sleep(1);
+			exec_background($command_string, $extra_args, true);
 			header('Location: router-devices.php?header=false');
 			exit;
 		}

--- a/setup.php
+++ b/setup.php
@@ -230,8 +230,13 @@ function routerconfigs_poller_bottom () {
 
 		$extra_args = ' -q ' . $config['base_path'] . '/plugins/routerconfigs/router-download.php';
 
-		if ($h > 0)
-		{
+		$daily = read_config_option('routerconfigs_hour');
+		if ($daily === false || $daily < 0 || $daily > 23) {
+			$daily = 0;
+		}
+		$daily = (int)$daily;
+
+		if ($h != $daily) {
 			$extra_args .= ' --retry';
 		}
 
@@ -261,6 +266,38 @@ function routerconfigs_config_settings () {
 			'friendly_name' => __('Debug Connection Buffer', 'routerconfigs'),
 			'description' => __('Whether to log direct output of device connection', 'routerconfigs'),
 			'method' => 'checkbox'
+		),
+		'routerconfigs_hour' => array(
+			'friendly_name' => __('Download Hour', 'routerconfigs'),
+			'description' => __('The hour of the day to perform the full downloads.', 'routerconfigs'),
+			'method' => 'drop_array',
+			'default' => '0',
+			'array' => array(
+				'0'  => __('00:00 (12am)', 1, 'routerconfigs'),
+				'1'  => __('01:00 (1am)', 1, 'routerconfigs'),
+				'2'  => __('02:00 (2am)', 1, 'routerconfigs'),
+				'3'  => __('03:00 (3am)', 1, 'routerconfigs'),
+				'4'  => __('04:00 (4am)', 1, 'routerconfigs'),
+				'5'  => __('05:00 (5am)', 1, 'routerconfigs'),
+				'6'  => __('06:00 (6am)', 1, 'routerconfigs'),
+				'7'  => __('07:00 (7am)', 1, 'routerconfigs'),
+				'8'  => __('08:00 (8am)', 1, 'routerconfigs'),
+				'9'  => __('09:00 (9am)', 1, 'routerconfigs'),
+				'10'  => __('10:00 (12am)', 1, 'routerconfigs'),
+				'11'  => __('11:00 (11am)', 1, 'routerconfigs'),
+				'12'  => __('12:00 (12pm)', 1, 'routerconfigs'),
+				'13'  => __('13:00 (1pm)', 1, 'routerconfigs'),
+				'14'  => __('14:00 (2pm)', 1, 'routerconfigs'),
+				'15'  => __('15:00 (3pm)', 1, 'routerconfigs'),
+				'16'  => __('16:00 (4pm)', 1, 'routerconfigs'),
+				'17'  => __('17:00 (5pm)', 1, 'routerconfigs'),
+				'18'  => __('18:00 (6pm)', 1, 'routerconfigs'),
+				'19'  => __('19:00 (7pm)', 1, 'routerconfigs'),
+				'20'  => __('20:00 (8pm)', 1, 'routerconfigs'),
+				'21'  => __('21:00 (9pm)', 1, 'routerconfigs'),
+				'22'  => __('22:00 (10pm)', 1, 'routerconfigs'),
+				'23'  => __('23:00 (11pm)', 1, 'routerconfigs'),
+			)
 		),
 		'routerconfigs_retention' => array(
 			'friendly_name' => __('Retention Period', 'routerconfigs'),
@@ -299,14 +336,6 @@ function routerconfigs_config_settings () {
 			'friendly_name' => __('Router Configs - Email', 'routerconfigs'),
 			'method' => 'spacer',
 		),
-		'routerconfigs_email' => array(
-			'friendly_name' => __('Email Address', 'routerconfigs'),
-			'description' => __('A comma delimited list of Email addresses to send the nightly backup Email to.', 'routerconfigs'),
-			'method' => 'textbox',
-			'size' => 40,
-			'max_length' => 255,
-			'default' => ''
-		),
 		'routerconfigs_from' => array(
 			'friendly_name' => __('From Address', 'routerconfigs'),
 			'description' => __('Email address the nightly backup will be sent from.', 'routerconfigs'),
@@ -314,7 +343,26 @@ function routerconfigs_config_settings () {
 			'size' => 40,
 			'max_length' => 255,
 			'default' => ''
-		)
+		),
+		'routerconfigs_name' => array(
+			'friendly_name' => __('From Name', 'routerconfigs'),
+			'description' => __('Name the nightly backup will be sent from.', 'routerconfigs'),
+			'method' => 'textbox',
+			'size' => 40,
+			'max_length' => 255,
+			'default' => ''
+		),
+		'routerconfigs_email' => array(
+			'friendly_name' => __('Email Address', 'routerconfigs'),
+			'description' => __('A comma delimited list of Email addresses to send the nightly backup Email to.', 'routerconfigs'),
+			'method' => 'textarea',
+			'class' => 'textAreaNotes',
+			'textarea_rows' => '5',
+			'textarea_cols' => '40',
+			'size' => 40,
+			'max_length' => 255,
+			'default' => ''
+		),
 	);
 
 	if (isset($settings['routerconfigs'])) {


### PR DESCRIPTION
# Version 1.3.2
- feature: Add two new options, email name and download hour
- feature: Expanded editing area of email to, so email addresses can be seen
- issue: Another attempt to correct automatic vs manual backups
- issue: Prevent 0/0 emails from being generated
- issue: Prevent endless loop when connecting via telnet and not enabled

This version does update the requirement to a minimum of 1.1.36 due to a fix to the SMTP routines that allow correct definition of the from details.