### PR TITLE
Version 1.3.3

### DIFF
--- a/INFO
+++ b/INFO
@@ -1,6 +1,6 @@
 [info]
 name = routerconfigs
-version = 1.3.2
+version = 1.3.3
 longname = Router Configs
 author = The Cacti Group
 email = 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * feature: Added field to clearly identify next automated retry time
 * feature: Added setting for retry schedule
 * feature: Rejigged device selection queries to use new fields
+* feature: Move failed backups to beginning of email as you are more worried about those!
 * issue: Fixed issue where number of rows for filter pages didn't match displayed rows
 * issue: Fixed issue where --retry option would not actually activate
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * feature: Move failed backups to beginning of email as you are more worried about those!
 * issue: Fixed issue where number of rows for filter pages didn't match displayed rows
 * issue: Fixed issue where --retry option would not actually activate
+* issue: Fixed issue where device was not marked for retry until after a connection was made
 
 --- 1.3.2 ---
 * feature: Add two new options, email name and download hour

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * feature: Added setting for retry schedule
 * feature: Rejigged device selection queries to use new fields
 * feature: Move failed backups to beginning of email as you are more worried about those!
+* issue: Fixed issue where hostname was incorrectly picked up and prevents wipe of hostname
 * issue: Fixed issue where number of rows for filter pages didn't match displayed rows
 * issue: Fixed issue where --retry option would not actually activate
 * issue: Fixed issue where device was not marked for retry until after a connection was made

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.
 * issue: Fixed issue where number of rows for filter pages didn't match displayed rows
 * issue: Fixed issue where --retry option would not actually activate
 * issue: Fixed issue where device was not marked for retry until after a connection was made
+* issue: Fixed issue where if date matched week, month or year, backup date would not show 'Today' even if it was today
 
 --- 1.3.2 ---
 * feature: Add two new options, email name and download hour

--- a/README.md
+++ b/README.md
@@ -40,12 +40,21 @@ On other operating systems, or for CentOS 7, you will have to find equivalent in
 Bug and feature enhancements for the routerconfigs plugin are handled in GitHub.  If you find a first search the Cacti forums for a solution before creating an issue in GitHub.
 
 ## ChangeLog
+--- 1.3.3 ---
+* feature: Added field to clearly identify next automated backup time
+* feature: Added field to clearly identify next automated retry time
+* feature: Added setting for retry schedule
+* feature: Rejigged device selection queries to use new fields
+* issue: Fixed issue where number of rows for filter pages didn't match displayed rows
+* issue: Fixed issue where --retry option would not actually activate
+
 --- 1.3.2 ---
 * feature: Add two new options, email name and download hour
 * feature: Expanded editing area of email to, so email addresses can be seen
 * issue: Another attempt to correct automatic vs manual backups
 * issue: Prevent 0/0 emails from being generated
 * issue: Prevent endless loop when connecting via telnet and not enabled
+* issue: Correct string requirement error for command line options
 
 --- 1.3.1 ---
 * feature: Parameters can now be specified with values separated by space ( ) or equals sign (=)

--- a/functions.php
+++ b/functions.php
@@ -559,19 +559,9 @@ function plugin_routerconfigs_download_config($device, $backuptime, $buffer_debu
 					}
 				}
 
-				if (substr($d, 0, 9) == 'hostname ') {
-					$filename = trim(substr($d, 9));
-					if ($device['hostname'] != $filename) {
-						db_execute_prepared('UPDATE plugin_routerconfigs_devices
-							SET hostname = ?
-							WHERE id = ?',
-							array($filename, $device['id']));
-					}
-				}
-
-				if (substr($d, 0, 17) == 'set system name ') {
-					$filename = trim(substr($d, 17));
-					if ($device['hostname'] != $filename) {
+				if (preg_match('~(host|set system )name ["]{0,1}([a-zA-Z0-9\._\-]+)["]{0,1}~i',$d,$matches)) {
+					$filename = trim($matches[2]);
+					if ($device['hostname'] != $filename && strlen($filename)) {
 						db_execute_prepared('UPDATE plugin_routerconfigs_devices
 							SET hostname = ?
 							WHERE id = ?',

--- a/router-devices.php
+++ b/router-devices.php
@@ -520,10 +520,6 @@ function show_devices() {
 		$num_rows = get_request_var('rows');
 	}
 
-	if (!($num_rows > 0)) {
-		$num_rows = 30;
-	}
-
 	if (isset_request_var('page')) {
 		$page = get_request_var('page');
 	}else{

--- a/router-devices.php
+++ b/router-devices.php
@@ -499,6 +499,12 @@ function devices_validate_vars() {
 	/* ================= input validation ================= */
 }
 
+function addDateToArray(&$date_array, $date, $text) {
+	if (!array_key_exists($date, $date_array)) {
+		$date_array[$date] = $text;
+	}
+}
+
 function show_devices() {
 	global $host, $username, $password, $command;
 	global $config, $device_actions, $acc, $item_rows;
@@ -514,6 +520,10 @@ function show_devices() {
 		$num_rows = get_request_var('rows');
 	}
 
+	if (!($num_rows > 0)) {
+		$num_rows = 30;
+	}
+
 	if (isset_request_var('page')) {
 		$page = get_request_var('page');
 	}else{
@@ -521,7 +531,6 @@ function show_devices() {
 	}
 
 	load_current_session_value('page', 'sess_routerconfigs_devices_current_page', '1');
-	$num_rows = 30;
 
 	$devicetype = '';
 	if (isset_request_var('devicetype')) {
@@ -733,8 +742,23 @@ function show_devices() {
 			'sort' => 'ASC',
 			'tip' => __('The IP address of this device', 'routerconfigs')
 		),
+		'nextbackup' => array(
+			'display' => __('Next Backup', 'routerconfigs'),
+			'align' => 'left',
+			'sort' => 'DESC',
+		),
 		'lastbackup' => array(
 			'display' => __('Date Backup', 'routerconfigs'),
+			'align' => 'left',
+			'sort' => 'DESC',
+		),
+		'nextattempt' => array(
+			'display' => __('Next Attempt', 'routerconfigs'),
+			'align' => 'left',
+			'sort' => 'DESC',
+		),
+		'lastattempt' => array(
+			'display' => __('Last Attempt', 'routerconfigs'),
 			'align' => 'left',
 			'sort' => 'DESC',
 		),
@@ -780,15 +804,14 @@ function show_devices() {
 		$date_month = $do_today->format('Y-m-01 \0\0:\0\0:\0\0');
 		$date_year = $do_today->modify('-1 year')->format('Y-m-d \0\0:\0\0:\0\0');
 
-		$date_array = array(
-			$date_today => __('Today', 'routerconfigs'),
-			$date_yesterday => __('Yesterday', 'routerconfigs'),
-			$date_week => '<i>'.__('This Week', 'routerconfigs').'</i>',
-			$date_month => '<u>'.__('This Month', 'routerconfigs').'</i>',
-			$date_year => '<u><i>'.__('Within a Year', 'routerconfigs').'</i></u>',
-			'2000-01-01 00:00:00' => '<b><i>'.__('Long, Long Ago', 'routerconfigs').'</b></i>',
-			'' => '<b><u>Never</u></b>'
-		);
+		$date_array = array();
+		addDateToArray($date_array, $date_today, __('Today', 'routerconfigs'));
+		addDateToArray($date_array, $date_yesterday, __('Yesterday', 'routerconfigs'));
+		addDateToArray($date_array, $date_week, '<i>'.__('This Week', 'routerconfigs').'</i>');
+		addDateToArray($date_array, $date_month, '<u>'.__('This Month', 'routerconfigs').'</i>');
+		addDateToArray($date_array, $date_year, '<u><i>'.__('Within a Year', 'routerconfigs').'</i></u>');
+		addDateToArray($date_array, '2000-01-01 00:00:00', '<b><i>'.__('Long, Long Ago', 'routerconfigs').'</b></i>');
+		addDateToArray($date_array, '', '<b><u>Never</u></b>');
 
 		foreach ($result as $row) {
 			form_alternate_row('line' . $row['id'], false);
@@ -838,7 +861,10 @@ function show_devices() {
 			form_selectable_cell(filter_value(__('Current', 'routerconfig'), get_request_var('filter'), 'router-devices.php?action=viewconfig&id=' . $row['id']).' - '.filter_value(__('Backups (%s)', $total, 'routerconfigs'), get_request_var('filter'), 'router-backups.php?device=' . $row['id']), $row['id'], '14%');
 
 			form_selectable_cell(filter_value($row['ipaddress'], get_request_var('filter')), $row['id'], '5%');
+			form_selectable_cell(filter_value(plugin_routerconfigs_date_from_time_with_na($row['nextbackup']), get_request_var('filter')), $row['id'], '10%');
 			form_selectable_cell(filter_value(plugin_routerconfigs_date_from_time_with_na($row['lastbackup']), get_request_var('filter')), $row['id'], '10%');
+			form_selectable_cell(filter_value(plugin_routerconfigs_date_from_time_with_na($row['nextattempt']), get_request_var('filter')), $row['id'], '10%');
+			form_selectable_cell(filter_value(plugin_routerconfigs_date_from_time_with_na($row['lastattempt']), get_request_var('filter')), $row['id'], '10%');
 			form_selectable_cell(filter_value(plugin_routerconfigs_date_from_time_with_na($row['lastchange']), get_request_var('filter')), $row['id'], '10%');
 			form_selectable_cell(filter_value($row['username'], get_request_var('filter')), $row['id'], '10%');
 			form_selectable_cell(filter_value($row['directory'], get_request_var('filter')), $row['id']);

--- a/router-download.php
+++ b/router-download.php
@@ -118,7 +118,6 @@ foreach($options as $arg => $value) {
 			break;
 		case 'r':
 		case 'retry':
-			echo "Retrying";
 			$retryMode = true;
 			break;
 		default:

--- a/router-download.php
+++ b/router-download.php
@@ -49,11 +49,14 @@ $longOpts  = array(
 	'devices:',
 	'debug',
 	'debug-buffer',
+	'retry',
 	'force',
 	'version',
-	'help'
+	'help',
+	'simulate-schedule'
 );
 
+$remaing = '';
 $options = routerconfigs_getopts($shortOpts, $longOpts, $remaining);
 
 include('./include/global.php');
@@ -67,6 +70,7 @@ $debugBuffer = false;
 $debug = false;
 $force = false;
 $devices = array();
+$simulate = false;
 
 foreach($options as $arg => $value) {
 	switch ($arg) {
@@ -99,6 +103,9 @@ foreach($options as $arg => $value) {
 			$debug = true;
 			$debugBuffer = true;
 			break;
+		case 'simulate-schedule':
+			$simulate = true;
+			break;
 		case 'f':
 		case 'force':
 			$force = true;
@@ -111,6 +118,7 @@ foreach($options as $arg => $value) {
 			break;
 		case 'r':
 		case 'retry':
+			echo "Retrying";
 			$retryMode = true;
 			break;
 		default:
@@ -118,8 +126,12 @@ foreach($options as $arg => $value) {
 	}
 }
 
+if (strlen($remaining)) {
+	routerconfigs_fail(EXIT_ARGERR, $remaining, true);
+}
+
 $devices = array_unique($devices);
-plugin_routerconfigs_download($retryMode, $force, $devices, $debugBuffer);
+plugin_routerconfigs_download($retryMode, $force, $devices, $debugBuffer, $simulate);
 exit(EXIT_NORMAL);
 
 function routerconfigs_fail($exit_value,$args = array(),$display_help = 0) {

--- a/setup.php
+++ b/setup.php
@@ -97,6 +97,21 @@ function routerconfigs_check_upgrade() {
 					ADD COLUMN `connect_type` varchar(10) DEFAULT \'both\'');
 			}
 		}
+
+		if (cacti_version_compare($old, '1.3.3', '<')) {
+			if (!db_column_exists('nextbackup','plugin_routerconfigs_devices')) {
+				db_execute('ALTER TABLE plugin_routerconfigs_devices
+					ADD COLUMN `nextbackup` int(18)');
+			}
+
+			if (!db_column_exists('connect_type','plugin_routerconfigs_devices')) {
+				db_execute('ALTER TABLE plugin_routerconfigs_devices
+					ADD COLUMN `nextattempt` int(18)');
+			}
+			db_execute('UPDATE plugin_routerconfigs_devices SET
+				nextbackup = 0,
+				nextattempt = 0');
+		}
 		db_execute("UPDATE plugin_config
 			SET version='$current'
 			WHERE directory='routerconfigs'");
@@ -161,7 +176,9 @@ function routerconfigs_setup_table_new() {
 	$data['columns'][] = array('name' => 'schedule', 'type' => 'int(11)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'lasterror', 'type' => 'varchar(255)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'lastbackup', 'type' => 'int(18)', 'NULL' => true);
+	$data['columns'][] = array('name' => 'nextbackup', 'type' => 'int(18)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'lastattempt', 'type' => 'int(18)', 'NULL' => true);
+	$data['columns'][] = array('name' => 'nextattempt', 'type' => 'int(18)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'devicetype', 'type' => 'int(11)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'connect_type', 'type' => 'varchar(10)', 'NULL' => false, 'default' => 'both');
 	$data['columns'][] = array('name' => 'debug', 'type' => 'longblob', 'NULL' => true);
@@ -297,6 +314,22 @@ function routerconfigs_config_settings () {
 				'21'  => __('21:00 (9pm)', 1, 'routerconfigs'),
 				'22'  => __('22:00 (10pm)', 1, 'routerconfigs'),
 				'23'  => __('23:00 (11pm)', 1, 'routerconfigs'),
+			)
+		),
+		'routerconfigs_retry' => array(
+			'friendly_name' => __('Retry Schedule', 'routerconfigs'),
+			'description' => __('The time to wait before attempting to perform an additional download when scheduled download fails', 'routerconfigs'),
+			'method' => 'drop_array',
+			'default' => '4',
+			'array' => array(
+				'0'  => __('Never', 1, 'routerconfigs'),
+				'1'  => __('1 hour', 2, 'routerconfigs'),
+				'2'  => __('2 hours', 1, 'routerconfigs'),
+				'3'  => __('3 hours', 1, 'routerconfigs'),
+				'4'  => __('4 hours', 1, 'routerconfigs'),
+				'6'  => __('6 hours', 1, 'routerconfigs'),
+				'8'  => __('8 hours', 1, 'routerconfigs'),
+				'12'  => __('12 hours', 1, 'routerconfigs'),
 			)
 		),
 		'routerconfigs_retention' => array(


### PR DESCRIPTION
This update brings with it the following changes:

- feature: Added field to clearly identify next automated backup time
- feature: Added field to clearly identify next automated retry time
- feature: Added setting for retry schedule
- feature: Rejigged device selection queries to use new fields
- feature: Move failed backups to beginning of email as you are more worried about those!
- issue: Fixed issue where number of rows for filter pages didn't match displayed rows
- issue: Fixed issue where hostname was incorrectly picked up and prevents wipe of hostname
- issue: Fixed issue where --retry option would not actually activate
- issue: Fixed issue where device was not marked for retry until after a connection was made
- issue: Fixed issue where if date matched week, month or year, backup date would not show 'Today' even if it was today
