### PR TITLE
docs: record recently merged security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # ChangeLog
+--- develop ---
+* issue: Defense-in-depth hardening for plugin_routerconfigs (PR #151)
 
 --- 1.7 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # ChangeLog
+
 --- develop ---
-* issue: Defense-in-depth hardening for plugin_routerconfigs (PR #151)
+
+* issue#151: Defense-in-depth hardening
 
 --- 1.7 ---
 


### PR DESCRIPTION
Adds the missing develop changelog entry for the recently merged security-hardening PR.

Closes #161